### PR TITLE
OSD-10500 Fix CVE for managed-prometheus-exporter-base  image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.5-230
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.5-240.1648458092
 
 
 ARG ocpythonlibver=0.13.1
 
 
-RUN microdnf install -y python39 tar gzip && microdnf clean all
+RUN microdnf install -y  python39 tar gzip && microdnf clean all
 
 RUN pip3 install "setuptools>=40.3.0" urllib3 chardet requests
 
@@ -18,4 +18,3 @@ RUN \
 RUN  pip3 install prometheus_client paramiko pyyaml boto3 slackclient && mkdir /openshift-python
 
 CMD [ "/bin/sh" ]
-

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM registry.access.redhat.com/ubi8/ubi-minimal:8.5-240.1648458092
 ARG ocpythonlibver=0.13.1
 
 
-RUN microdnf install -y  python39 tar gzip && microdnf clean all
+RUN microdnf install -y python39 tar gzip && microdnf clean all
 
 RUN pip3 install "setuptools>=40.3.0" urllib3 chardet requests
 


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/OSD-10500,

This will fix CVE for [RHSA-2022:0951: expat security update] also  for RHSA-2022:1065: openssl security update (Important) and RHSA-2022:0658: cyrus-sasl security update (Important) , both packages are not installed and command is not used in Dockerfile