### PR TITLE
Removes mwoodson from owners

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,6 +1,4 @@
 approvers:
 - jewzaam
-- mwoodson
 reviewers:
 - jewzaam
-- mwoodson


### PR DESCRIPTION
Removes mwoodson from the OWNERS file.

We should probably also identify a team to properly "own" this.